### PR TITLE
Add quotes to -framework OpenCL

### DIFF
--- a/configure
+++ b/configure
@@ -2734,7 +2734,7 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 case $host_os in
     darwin* )
-        PKG_LIBS=-framework OpenCL
+        PKG_LIBS="-framework OpenCL"
         echo "Darwin OS"
         CXX="clang++"
         CXXCPP="clang++ -E -std=gnu++11"


### PR DESCRIPTION
Very small change to remove error message during pre-build:

...
checking build system type... x86_64-apple-darwin15.2.0
checking host system type... x86_64-apple-darwin15.2.0
**./configure: line 2737: OpenCL: command not found**
Darwin OS
checking "Checking OpenCL C++ API"... checking for grep that handles long lines and -e... /usr/bin/grep
...
