### PR TITLE
Bringing back initContexts() without loading failure

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,7 +9,7 @@
     if (!identical(Sys.getenv("APPVEYOR"), "True") && !identical(Sys.getenv("TRAVIS"), "true")) {
         # initialize contexts
         # default_device <- initContexts()
-        # initContexts()
+        initContexts()
         print("context initialization successful")
         # packageStartupMessage(paste0("gpuR ", packageVersion('gpuR'), "\nDefault device: ", default_device))
         packageStartupMessage(paste0("gpuR ", packageVersion('gpuR')))

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -36,6 +36,7 @@ void initContexts(){
         for(unsigned int gpu_idx = 0; gpu_idx < devices.size(); gpu_idx++) {
             
             Rcpp::Rcout << "  - gpu index: " << gpu_idx << std::endl;
+            viennacl::ocl::set_context_platform_index(id, plat_idx);
             viennacl::ocl::setup_context(id, devices[gpu_idx]);
             Rcpp::Rcout << "    - " << devices[gpu_idx].name() << std::endl;
             

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,4 +1,3 @@
-
 #include "gpuR/windows_check.hpp"
 // #include "gpuR/cl_helpers.hpp"
 
@@ -25,52 +24,31 @@ void initContexts(){
     typedef std::vector< viennacl::ocl::platform > platforms_type;
     platforms_type platforms = viennacl::ocl::get_platforms();
     
-    std::cout << "Number of platforms: " << platforms.size() << std::endl;
+    Rcpp::Rcout << "Number of platforms: " << platforms.size() << std::endl;
     
-    for(unsigned int plat_idx=0; plat_idx < platforms.size(); plat_idx++){
+    for(unsigned int plat_idx = 0; plat_idx < platforms.size(); plat_idx++) {
         
-        std::cout << "platform: " << platforms[plat_idx].info() << std::endl;
+        Rcpp::Rcout << "- platform: " << platforms[plat_idx].info() << std::endl;
     
         std::vector< viennacl::ocl::device > devices;
         devices = platforms[plat_idx].devices();
     
-        for(unsigned int gpu_idx=0; gpu_idx < devices.size(); gpu_idx++){
+        for(unsigned int gpu_idx = 0; gpu_idx < devices.size(); gpu_idx++) {
             
-            std::cout << "gpu index: " << gpu_idx << std::endl;
-                    
-            // Select the platform
-            viennacl::ocl::switch_context(id);
-            viennacl::ocl::set_context_platform_index(id, plat_idx);
-            
-            // Get available devices
-            //            std::vector<viennacl::ocl::device> const & devices = viennacl::ocl::platform().devices();
-            
-            //            std::cout << devices[gpu_idx].name() << std::endl;
-            
-            // take the n-th available device from 'devices'
-            //            std::vector< viennacl::ocl::device > my_devices;
-            //            my_devices.push_back(devices[gpu_idx]);
-            
-            // Select device
-            //            viennacl::ocl::setup_context(id, my_devices);
-            //            viennacl::ocl::current_context().switch_device(gpu_idx);
+            Rcpp::Rcout << "  - gpu index: " << gpu_idx << std::endl;
             viennacl::ocl::setup_context(id, devices[gpu_idx]);
-            //            viennacl::ocl::get_context(id).switch_device(gpu_idx);
-            std::cout << viennacl::ocl::current_context().current_device().name() << std::endl;
+            Rcpp::Rcout << "    - " << devices[gpu_idx].name() << std::endl;
             
             // increment context
             id++;
         }
     }
     
-    std::cout << "checked all devices" << std::endl;
+    Rcpp::Rcout << "checked all devices" << std::endl;
     
     viennacl::ocl::switch_context(0);
     
-    std::cout << "completed initialization" << std::endl;
-    
-    // std::cout << viennacl::ocl::current_context().current_device().name() << std::endl;
-    // return wrap(viennacl::ocl::current_context().current_device().name());
+    Rcpp::Rcout << "completed initialization" << std::endl;
 }
 
 
@@ -120,7 +98,6 @@ listContexts()
 {
     // declarations
     int id = 0;
-    long current_context_id = viennacl::ocl::backend<>::current_context_id();
     int num_contexts = 0;
     //int num_devices;
     typedef std::vector< viennacl::ocl::platform > platforms_type;
@@ -147,30 +124,26 @@ listContexts()
 //    Rcout << "number of total contexts to create" << std::endl;
 //    Rcout << num_contexts << std::endl;
     
-    Rcpp::IntegerVector context_index(num_contexts);
+    Rcpp::IntegerVector   context_index(num_contexts);
     Rcpp::CharacterVector platform_name(num_contexts);
-    Rcpp::IntegerVector platform_index(num_contexts);
+    Rcpp::IntegerVector   platform_index(num_contexts);
     Rcpp::CharacterVector device_name(num_contexts);
-    Rcpp::IntegerVector device_index(num_contexts);
+    Rcpp::IntegerVector   device_index(num_contexts);
     Rcpp::CharacterVector device_type(num_contexts);
     
     
-    for(unsigned int plat_idx=0; plat_idx < platforms.size(); plat_idx++){
+    for(unsigned int plat_idx = 0; plat_idx < platforms.size(); plat_idx++) {
         
         std::vector< viennacl::ocl::device > devices;
         devices = platforms[plat_idx].devices();
         
-        for(unsigned int gpu_idx=0; gpu_idx < devices.size(); gpu_idx++){
+        for(unsigned int gpu_idx = 0; gpu_idx < devices.size(); gpu_idx++) {
         
 //            Rcout << "context id" << std::endl;
 //            Rcout << id << std::endl;
             
 //            Rcout << "current platform index" << std::endl;
 //            Rcout << plat_idx << std::endl;
-            
-            // Select the platform
-            viennacl::ocl::switch_context(id);
-            // viennacl::ocl::set_context_platform_index(id, plat_idx);
             
             context_index[id] = id + 1;
             platform_index[id] = plat_idx;
@@ -187,7 +160,7 @@ listContexts()
             
             // Get device info
             device_index[id] = gpu_idx;
-            device_name[id] = platforms[plat_idx].devices()[gpu_idx].name();
+            device_name[id] = devices[gpu_idx].name();
             // device_name[id] = viennacl::ocl::current_device().name();
             
 //            Rcout << "current device index" << std::endl;
@@ -196,7 +169,7 @@ listContexts()
 //            Rcout << "current device name" << std::endl;
 //            Rcout << device_name[id] << std::endl;
             
-            switch(viennacl::ocl::current_device().type()){
+            switch(devices[gpu_idx].type()){
                 case 2: 
                     device_type[id] = "cpu";
                     break;
@@ -207,8 +180,8 @@ listContexts()
                     device_type[id] = "accelerator";
                     break;
                 default:
-                    Rcpp::Rcout << "device found" << std::endl;
-                    Rcpp::Rcout << viennacl::ocl::current_device().type() << std::endl;
+                    Rcpp::Rcout << "device found: " << std::endl;
+                    Rcpp::Rcout << devices[gpu_idx].type() << std::endl;
                     throw Rcpp::exception("unrecognized device detected");
             }
         
@@ -216,8 +189,6 @@ listContexts()
             id++;
         }
     }
-    
-    viennacl::ocl::switch_context(current_context_id);
     
     return Rcpp::DataFrame::create(Rcpp::Named("context") = context_index,
     			  Rcpp::Named("platform") = platform_name,
@@ -246,7 +217,7 @@ cpp_setContext(int id)
     if(id <= 0){
         stop("Index cannot be 0 or less");
     }
-    viennacl::ocl::switch_context(id-1);
+    viennacl::ocl::switch_context(id - 1);
 }
 
 


### PR DESCRIPTION
After some testing it turns out that calling `viennacl::ocl::current_context()` is the cause of the loading failure mentioned in #9, even though the reason is still unclear. Since this issue only happens for Intel GPU, it may be out of our control.

What we can do is

- Do not call `viennacl::ocl::current_context()` in `initContexts()`. This is possible since we only need to **setup** a context without actually **using** it.
- Give the freedom to user to select the proper GPU for real computing. Avoid using Intel GPU if possible.

After applying this patch, my startup message and results for some function calls are as follows.

```r
library(gpuR)
## Number of platforms: 2
## - platform: Intel(R) Corporation: OpenCL 1.2 
##   - gpu index: 0
##     - Intel(R) HD Graphics 4600
## - platform: NVIDIA Corporation: OpenCL 1.2 CUDA 8.0.0
##   - gpu index: 0
##     - GeForce GTX 850M
## checked all devices
## completed initialization
## [1] "context initialization successful"
## gpuR 1.1.4
## [1] "startup message not problem"
currentContext()
## [1] 1
listContexts()
##   context                                  platform platform_index
## 1       1         Intel(R) Corporation: OpenCL 1.2               0
## 2       2 NVIDIA Corporation: OpenCL 1.2 CUDA 8.0.0              1
##                      device device_index device_type
## 1 Intel(R) HD Graphics 4600            0         gpu
## 2          GeForce GTX 850M            0         gpu
setContext(2L)
currentContext()
## [1] 2
currentDevice()
## $device
## [1] "GeForce GTX 850M"
## 
## $device_index
## [1] 1
## 
## $device_type
## [1] "gpu"
```