### PR TITLE
Add the sum method for vclVector objects

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -278,18 +278,6 @@ truncDoublegpuMat <- function(ptrA_, nr, nc) {
     .Call(`_gpuR_truncDoublegpuMat`, ptrA_, nr, nc)
 }
 
-cpp_vcl_nrow <- function(ptrA, type_flag) {
-    .Call(`_gpuR_cpp_vcl_nrow`, ptrA, type_flag)
-}
-
-cpp_vcl_ncol <- function(ptrA, type_flag) {
-    .Call(`_gpuR_cpp_vcl_ncol`, ptrA, type_flag)
-}
-
-cpp_vclVector_size <- function(ptrA, type_flag) {
-    .Call(`_gpuR_cpp_vclVector_size`, ptrA, type_flag)
-}
-
 cpp_gpuVector_size <- function(ptrA, type_flag) {
     .Call(`_gpuR_cpp_gpuVector_size`, ptrA, type_flag)
 }
@@ -312,6 +300,18 @@ cpp_gpuMatrix_nrow <- function(ptrA, type_flag) {
 
 cpp_gpuMatrix_ncol <- function(ptrA, type_flag) {
     .Call(`_gpuR_cpp_gpuMatrix_ncol`, ptrA, type_flag)
+}
+
+cpp_vcl_nrow <- function(ptrA, type_flag) {
+    .Call(`_gpuR_cpp_vcl_nrow`, ptrA, type_flag)
+}
+
+cpp_vcl_ncol <- function(ptrA, type_flag) {
+    .Call(`_gpuR_cpp_vcl_ncol`, ptrA, type_flag)
+}
+
+cpp_vclVector_size <- function(ptrA, type_flag) {
+    .Call(`_gpuR_cpp_vclVector_size`, ptrA, type_flag)
 }
 
 cpp_identity_vclMatrix <- function(ptrA, type_flag) {
@@ -876,6 +876,10 @@ cpp_vclMatrix_rowsum <- function(ptrA, ptrB, type_flag) {
 
 cpp_vclMatrix_sum <- function(ptrA, type_flag) {
     .Call(`_gpuR_cpp_vclMatrix_sum`, ptrA, type_flag)
+}
+
+cpp_vclVector_sum <- function(ptrA, type_flag) {
+    .Call(`_gpuR_cpp_vclVector_sum`, ptrA, type_flag)
 }
 
 cpp_vclMatrix_svd <- function(ptrA, ptrD, ptrU, ptrV, type_flag, ctx_id) {

--- a/R/methods-vclVector.R
+++ b/R/methods-vclVector.R
@@ -588,6 +588,7 @@ setMethod("Summary", c(x="vclVector"),
               result <- switch(op,
                                `max` = vclVecMax(x),
                                `min` = vclVecMin(x),
+                               `sum` = vclVecSum(x),
                                stop("undefined operation")
               )
               return(result)

--- a/R/wrappers-vclVector.R
+++ b/R/wrappers-vclVector.R
@@ -60,4 +60,22 @@ vclVecMin <- function(A){
     return(C)
 }
 
+# GPU Vector sum
+vclVecSum <- function(A){
+    
+    type <- typeof(A)
+    
+    C <- switch(type,
+                integer = {
+                    stop("integer not currently implemented")
+                },
+                float = {cpp_vclVector_sum(A@address, 6L)
+                },
+                double = {
+                    cpp_vclVector_sum(A@address, 8L)
+                },
+                stop("type not recognized")
+    )
+    return(C)
+}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -761,42 +761,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// cpp_vcl_nrow
-SEXP cpp_vcl_nrow(SEXP ptrA, const int type_flag);
-RcppExport SEXP _gpuR_cpp_vcl_nrow(SEXP ptrASEXP, SEXP type_flagSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< SEXP >::type ptrA(ptrASEXP);
-    Rcpp::traits::input_parameter< const int >::type type_flag(type_flagSEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_vcl_nrow(ptrA, type_flag));
-    return rcpp_result_gen;
-END_RCPP
-}
-// cpp_vcl_ncol
-SEXP cpp_vcl_ncol(SEXP ptrA, const int type_flag);
-RcppExport SEXP _gpuR_cpp_vcl_ncol(SEXP ptrASEXP, SEXP type_flagSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< SEXP >::type ptrA(ptrASEXP);
-    Rcpp::traits::input_parameter< const int >::type type_flag(type_flagSEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_vcl_ncol(ptrA, type_flag));
-    return rcpp_result_gen;
-END_RCPP
-}
-// cpp_vclVector_size
-SEXP cpp_vclVector_size(SEXP ptrA, const int type_flag);
-RcppExport SEXP _gpuR_cpp_vclVector_size(SEXP ptrASEXP, SEXP type_flagSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< SEXP >::type ptrA(ptrASEXP);
-    Rcpp::traits::input_parameter< const int >::type type_flag(type_flagSEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_vclVector_size(ptrA, type_flag));
-    return rcpp_result_gen;
-END_RCPP
-}
 // cpp_gpuVector_size
 SEXP cpp_gpuVector_size(SEXP ptrA, const int type_flag);
 RcppExport SEXP _gpuR_cpp_gpuVector_size(SEXP ptrASEXP, SEXP type_flagSEXP) {
@@ -867,6 +831,42 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type ptrA(ptrASEXP);
     Rcpp::traits::input_parameter< const int >::type type_flag(type_flagSEXP);
     rcpp_result_gen = Rcpp::wrap(cpp_gpuMatrix_ncol(ptrA, type_flag));
+    return rcpp_result_gen;
+END_RCPP
+}
+// cpp_vcl_nrow
+SEXP cpp_vcl_nrow(SEXP ptrA, const int type_flag);
+RcppExport SEXP _gpuR_cpp_vcl_nrow(SEXP ptrASEXP, SEXP type_flagSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type ptrA(ptrASEXP);
+    Rcpp::traits::input_parameter< const int >::type type_flag(type_flagSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_vcl_nrow(ptrA, type_flag));
+    return rcpp_result_gen;
+END_RCPP
+}
+// cpp_vcl_ncol
+SEXP cpp_vcl_ncol(SEXP ptrA, const int type_flag);
+RcppExport SEXP _gpuR_cpp_vcl_ncol(SEXP ptrASEXP, SEXP type_flagSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type ptrA(ptrASEXP);
+    Rcpp::traits::input_parameter< const int >::type type_flag(type_flagSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_vcl_ncol(ptrA, type_flag));
+    return rcpp_result_gen;
+END_RCPP
+}
+// cpp_vclVector_size
+SEXP cpp_vclVector_size(SEXP ptrA, const int type_flag);
+RcppExport SEXP _gpuR_cpp_vclVector_size(SEXP ptrASEXP, SEXP type_flagSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type ptrA(ptrASEXP);
+    Rcpp::traits::input_parameter< const int >::type type_flag(type_flagSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_vclVector_size(ptrA, type_flag));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2849,6 +2849,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// cpp_vclVector_sum
+SEXP cpp_vclVector_sum(SEXP ptrA, const int type_flag);
+RcppExport SEXP _gpuR_cpp_vclVector_sum(SEXP ptrASEXP, SEXP type_flagSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type ptrA(ptrASEXP);
+    Rcpp::traits::input_parameter< const int >::type type_flag(type_flagSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_vclVector_sum(ptrA, type_flag));
+    return rcpp_result_gen;
+END_RCPP
+}
 // cpp_vclMatrix_svd
 void cpp_vclMatrix_svd(SEXP ptrA, SEXP ptrD, SEXP ptrU, SEXP ptrV, int type_flag, int ctx_id);
 RcppExport SEXP _gpuR_cpp_vclMatrix_svd(SEXP ptrASEXP, SEXP ptrDSEXP, SEXP ptrUSEXP, SEXP ptrVSEXP, SEXP type_flagSEXP, SEXP ctx_idSEXP) {
@@ -2938,15 +2950,15 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gpuR_truncIntgpuMat", (DL_FUNC) &_gpuR_truncIntgpuMat, 3},
     {"_gpuR_truncFloatgpuMat", (DL_FUNC) &_gpuR_truncFloatgpuMat, 3},
     {"_gpuR_truncDoublegpuMat", (DL_FUNC) &_gpuR_truncDoublegpuMat, 3},
-    {"_gpuR_cpp_vcl_nrow", (DL_FUNC) &_gpuR_cpp_vcl_nrow, 2},
-    {"_gpuR_cpp_vcl_ncol", (DL_FUNC) &_gpuR_cpp_vcl_ncol, 2},
-    {"_gpuR_cpp_vclVector_size", (DL_FUNC) &_gpuR_cpp_vclVector_size, 2},
     {"_gpuR_cpp_gpuVector_size", (DL_FUNC) &_gpuR_cpp_gpuVector_size, 2},
     {"_gpuR_cpp_gpuVector_max", (DL_FUNC) &_gpuR_cpp_gpuVector_max, 3},
     {"_gpuR_cpp_gpuMatrix_max", (DL_FUNC) &_gpuR_cpp_gpuMatrix_max, 2},
     {"_gpuR_cpp_gpuMatrix_min", (DL_FUNC) &_gpuR_cpp_gpuMatrix_min, 2},
     {"_gpuR_cpp_gpuMatrix_nrow", (DL_FUNC) &_gpuR_cpp_gpuMatrix_nrow, 2},
     {"_gpuR_cpp_gpuMatrix_ncol", (DL_FUNC) &_gpuR_cpp_gpuMatrix_ncol, 2},
+    {"_gpuR_cpp_vcl_nrow", (DL_FUNC) &_gpuR_cpp_vcl_nrow, 2},
+    {"_gpuR_cpp_vcl_ncol", (DL_FUNC) &_gpuR_cpp_vcl_ncol, 2},
+    {"_gpuR_cpp_vclVector_size", (DL_FUNC) &_gpuR_cpp_vclVector_size, 2},
     {"_gpuR_cpp_identity_vclMatrix", (DL_FUNC) &_gpuR_cpp_identity_vclMatrix, 2},
     {"_gpuR_cpp_vclMatrix_get_diag", (DL_FUNC) &_gpuR_cpp_vclMatrix_get_diag, 3},
     {"_gpuR_cpp_vclMat_vclVec_set_diag", (DL_FUNC) &_gpuR_cpp_vclMat_vclVec_set_diag, 3},
@@ -3088,6 +3100,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gpuR_cpp_vclMatrix_rowmean", (DL_FUNC) &_gpuR_cpp_vclMatrix_rowmean, 3},
     {"_gpuR_cpp_vclMatrix_rowsum", (DL_FUNC) &_gpuR_cpp_vclMatrix_rowsum, 3},
     {"_gpuR_cpp_vclMatrix_sum", (DL_FUNC) &_gpuR_cpp_vclMatrix_sum, 2},
+    {"_gpuR_cpp_vclVector_sum", (DL_FUNC) &_gpuR_cpp_vclVector_sum, 2},
     {"_gpuR_cpp_vclMatrix_svd", (DL_FUNC) &_gpuR_cpp_vclMatrix_svd, 6},
     {"_gpuR_cpp_gpuMatrix_svd", (DL_FUNC) &_gpuR_cpp_gpuMatrix_svd, 5},
     {NULL, NULL, 0}

--- a/src/vienna_stats.cpp
+++ b/src/vienna_stats.cpp
@@ -1,4 +1,3 @@
-
 #include "gpuR/windows_check.hpp"
 
 // eigen headers for handling the R input data
@@ -218,6 +217,18 @@ cpp_vclMatrix_sum(
     viennacl::matrix_range<viennacl::matrix<T> > vcl_A = ptrA->data();
     
     T res = viennacl::linalg::sum(viennacl::linalg::row_sum(vcl_A));
+    return wrap(res);
+}
+
+template <typename T>
+SEXP
+cpp_vclVector_sum(
+    SEXP ptrA_)
+{    
+    Rcpp::XPtr<dynVCLVec<T> > pA(ptrA_);
+    viennacl::vector_range<viennacl::vector_base<T> > vcl_A  = pA->data();
+    
+    T res = viennacl::linalg::sum(vcl_A);
     return wrap(res);
 }
 
@@ -1098,6 +1109,23 @@ cpp_vclMatrix_sum(
         return cpp_vclMatrix_sum<float>(ptrA);
     case 8:
         return cpp_vclMatrix_sum<double>(ptrA);
+    default:
+        throw Rcpp::exception("unknown type detected for vclMatrix object!");
+    }
+}
+// [[Rcpp::export]]
+SEXP
+cpp_vclVector_sum(
+    SEXP ptrA,
+    const int type_flag)
+{
+    switch(type_flag) {
+    case 4:
+        return cpp_vclVector_sum<int>(ptrA);
+    case 6:
+        return cpp_vclVector_sum<float>(ptrA);
+    case 8:
+        return cpp_vclVector_sum<double>(ptrA);
     default:
         throw Rcpp::exception("unknown type detected for vclMatrix object!");
     }


### PR DESCRIPTION
Dear Mr Determan, thank you for your efforts with gpuR!

While using it I noticed there is no sum() method for vclVectors, so I went ahead and added one, based on the one for vclMatrix. Please let me know if I can do anything more, or differently, to get it merged.